### PR TITLE
Refactor audio a bit

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -98,7 +98,7 @@ By returning `EntityCommands`, you can easily chain multiple widgets together an
 Define your assets in an enum so each variant maps to a `Handle`:
 
 ```rust
-#[derive(PartialEq, Eq, Hash, Reflect)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Reflect)]
 pub enum SpriteKey {
     Player,
     Enemy,

--- a/src/game/animation.rs
+++ b/src/game/animation.rs
@@ -71,7 +71,7 @@ fn trigger_step_sfx(mut commands: Commands, mut step_query: Query<&PlayerAnimati
             && animation.changed()
             && (animation.frame == 2 || animation.frame == 5)
         {
-            commands.trigger(PlaySfx::Step);
+            commands.trigger(PlaySfx::RandomStep);
         }
     }
 }

--- a/src/game/animation.rs
+++ b/src/game/animation.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use bevy::prelude::*;
 
-use super::{audio::sfx::Sfx, movement::MovementController};
+use super::{audio::sfx::PlaySfx, movement::MovementController};
 use crate::AppSet;
 
 pub(super) fn plugin(app: &mut App) {
@@ -71,7 +71,7 @@ fn trigger_step_sfx(mut commands: Commands, mut step_query: Query<&PlayerAnimati
             && animation.changed()
             && (animation.frame == 2 || animation.frame == 5)
         {
-            commands.trigger(Sfx::Step);
+            commands.trigger(PlaySfx::Step);
         }
     }
 }

--- a/src/game/assets.rs
+++ b/src/game/assets.rs
@@ -15,7 +15,7 @@ pub(super) fn plugin(app: &mut App) {
     app.init_resource::<HandleMap<SoundtrackKey>>();
 }
 
-#[derive(PartialEq, Eq, Hash, Reflect)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Reflect)]
 pub enum ImageKey {
     Ducky,
 }
@@ -40,7 +40,7 @@ impl FromWorld for HandleMap<ImageKey> {
     }
 }
 
-#[derive(PartialEq, Eq, Hash, Reflect)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Reflect)]
 pub enum SfxKey {
     ButtonHover,
     ButtonPress,
@@ -75,7 +75,7 @@ impl FromWorld for HandleMap<SfxKey> {
     }
 }
 
-#[derive(PartialEq, Eq, Hash, Reflect)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Reflect)]
 pub enum SoundtrackKey {
     Credits,
     Gameplay,

--- a/src/game/audio/mod.rs
+++ b/src/game/audio/mod.rs
@@ -2,24 +2,7 @@ pub mod sfx;
 pub mod soundtrack;
 
 use bevy::prelude::*;
-use sfx::Sfx;
 
 pub fn plugin(app: &mut App) {
-    app.add_systems(Update, button_interaction_sfx);
-
-    app.observe(soundtrack::play_soundtrack);
-    app.observe(sfx::play_sfx);
-}
-
-fn button_interaction_sfx(
-    mut interactions: Query<&'static Interaction, Changed<Interaction>>,
-    mut commands: Commands,
-) {
-    for interaction in &mut interactions {
-        match interaction {
-            Interaction::Hovered => commands.trigger(Sfx::ButtonHover),
-            Interaction::Pressed => commands.trigger(Sfx::ButtonPress),
-            _ => {}
-        }
-    }
+    app.add_plugins((sfx::plugin, soundtrack::plugin));
 }

--- a/src/game/audio/sfx.rs
+++ b/src/game/audio/sfx.rs
@@ -12,13 +12,12 @@ fn play_sfx(
     mut commands: Commands,
     sfx_handles: Res<HandleMap<SfxKey>>,
 ) {
+    let sfx_key = match trigger.event() {
+        PlaySfx::Key(key) => *key,
+        PlaySfx::RandomStep => random_step(),
+    };
     commands.spawn(AudioSourceBundle {
-        source: sfx_handles[&match trigger.event() {
-            PlaySfx::ButtonHover => SfxKey::ButtonHover,
-            PlaySfx::ButtonPress => SfxKey::ButtonPress,
-            PlaySfx::Step => random_step(),
-        }]
-            .clone_weak(),
+        source: sfx_handles[&sfx_key].clone_weak(),
         settings: PlaybackSettings {
             mode: PlaybackMode::Despawn,
             ..default()
@@ -29,9 +28,8 @@ fn play_sfx(
 /// Trigger this event to play a single sound effect.
 #[derive(Event)]
 pub enum PlaySfx {
-    ButtonHover,
-    ButtonPress,
-    Step,
+    Key(SfxKey),
+    RandomStep,
 }
 
 fn random_step() -> SfxKey {

--- a/src/game/audio/soundtrack.rs
+++ b/src/game/audio/soundtrack.rs
@@ -2,43 +2,49 @@ use bevy::{audio::PlaybackMode, prelude::*};
 
 use crate::game::assets::{HandleMap, SoundtrackKey};
 
-pub(super) fn play_soundtrack(
-    trigger: Trigger<Soundtrack>,
-    mut commands: Commands,
-    soundtrack_handles: Res<HandleMap<SoundtrackKey>>,
-    query: Query<Entity, With<SoundtrackMarker>>,
-) {
-    let event = trigger.event();
-    for entity in query.iter() {
-        commands.entity(entity).despawn();
-    }
-
-    let source = match event {
-        Soundtrack::Disable => {
-            return;
-        }
-        Soundtrack::Credits => &soundtrack_handles[&SoundtrackKey::Credits],
-        Soundtrack::Gameplay => &soundtrack_handles[&SoundtrackKey::Gameplay],
-    }
-    .clone_weak();
-
-    let settings = PlaybackSettings {
-        mode: PlaybackMode::Loop,
-        ..default()
-    };
-    commands.spawn((AudioSourceBundle { source, settings }, SoundtrackMarker));
+pub(super) fn plugin(app: &mut App) {
+    app.register_type::<IsSoundtrack>();
+    app.observe(play_soundtrack);
 }
 
-/// We mark our soundtrack entity so we can find it later.
-#[derive(Component)]
-pub(super) struct SoundtrackMarker;
+fn play_soundtrack(
+    trigger: Trigger<PlaySoundtrack>,
+    mut commands: Commands,
+    soundtrack_handles: Res<HandleMap<SoundtrackKey>>,
+    soundtrack_query: Query<Entity, With<IsSoundtrack>>,
+) {
+    for entity in &soundtrack_query {
+        commands.entity(entity).despawn_recursive();
+    }
 
-/// Play or disable the soundtrack.
+    commands.spawn((
+        AudioSourceBundle {
+            source: soundtrack_handles[&match trigger.event() {
+                PlaySoundtrack::Disable => return,
+                PlaySoundtrack::Credits => SoundtrackKey::Credits,
+                PlaySoundtrack::Gameplay => SoundtrackKey::Gameplay,
+            }]
+                .clone_weak(),
+            settings: PlaybackSettings {
+                mode: PlaybackMode::Loop,
+                ..default()
+            },
+        },
+        IsSoundtrack,
+    ));
+}
+
+/// Trigger this event to play or disable the soundtrack.
 /// Playing a new soundtrack will overwrite the previous one.
 /// Soundtracks will loop.
 #[derive(Event)]
-pub enum Soundtrack {
+pub enum PlaySoundtrack {
+    Disable,
     Credits,
     Gameplay,
-    Disable,
 }
+
+/// Marker component for the soundtrack entity so we can find it later.
+#[derive(Component, Reflect)]
+#[reflect(Component)]
+struct IsSoundtrack;

--- a/src/game/audio/soundtrack.rs
+++ b/src/game/audio/soundtrack.rs
@@ -17,14 +17,13 @@ fn play_soundtrack(
         commands.entity(entity).despawn_recursive();
     }
 
+    let soundtrack_key = match trigger.event() {
+        PlaySoundtrack::Key(key) => *key,
+        PlaySoundtrack::Disable => return,
+    };
     commands.spawn((
         AudioSourceBundle {
-            source: soundtrack_handles[&match trigger.event() {
-                PlaySoundtrack::Disable => return,
-                PlaySoundtrack::Credits => SoundtrackKey::Credits,
-                PlaySoundtrack::Gameplay => SoundtrackKey::Gameplay,
-            }]
-                .clone_weak(),
+            source: soundtrack_handles[&soundtrack_key].clone_weak(),
             settings: PlaybackSettings {
                 mode: PlaybackMode::Loop,
                 ..default()
@@ -39,9 +38,8 @@ fn play_soundtrack(
 /// Soundtracks will loop.
 #[derive(Event)]
 pub enum PlaySoundtrack {
+    Key(SoundtrackKey),
     Disable,
-    Credits,
-    Gameplay,
 }
 
 /// Marker component for the soundtrack entity so we can find it later.

--- a/src/screen/credits.rs
+++ b/src/screen/credits.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::*;
 
 use super::Screen;
-use crate::{game::audio::soundtrack::Soundtrack, ui::prelude::*};
+use crate::{game::audio::soundtrack::PlaySoundtrack, ui::prelude::*};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Credits), enter_credits);
@@ -39,11 +39,11 @@ fn enter_credits(mut commands: Commands) {
             children.button("Back").insert(CreditsAction::Back);
         });
 
-    commands.trigger(Soundtrack::Credits);
+    commands.trigger(PlaySoundtrack::Credits);
 }
 
 fn exit_credits(mut commands: Commands) {
-    commands.trigger(Soundtrack::Disable);
+    commands.trigger(PlaySoundtrack::Disable);
 }
 
 fn handle_credits_action(

--- a/src/screen/credits.rs
+++ b/src/screen/credits.rs
@@ -3,7 +3,10 @@
 use bevy::prelude::*;
 
 use super::Screen;
-use crate::{game::audio::soundtrack::PlaySoundtrack, ui::prelude::*};
+use crate::{
+    game::{assets::SoundtrackKey, audio::soundtrack::PlaySoundtrack},
+    ui::prelude::*,
+};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Credits), enter_credits);
@@ -39,7 +42,7 @@ fn enter_credits(mut commands: Commands) {
             children.button("Back").insert(CreditsAction::Back);
         });
 
-    commands.trigger(PlaySoundtrack::Credits);
+    commands.trigger(PlaySoundtrack::Key(SoundtrackKey::Credits));
 }
 
 fn exit_credits(mut commands: Commands) {

--- a/src/screen/playing.rs
+++ b/src/screen/playing.rs
@@ -3,7 +3,7 @@
 use bevy::{input::common_conditions::input_just_pressed, prelude::*};
 
 use super::Screen;
-use crate::game::{audio::soundtrack::Soundtrack, spawn::level::SpawnLevel};
+use crate::game::{audio::soundtrack::PlaySoundtrack, spawn::level::SpawnLevel};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Playing), enter_playing);
@@ -18,12 +18,12 @@ pub(super) fn plugin(app: &mut App) {
 
 fn enter_playing(mut commands: Commands) {
     commands.trigger(SpawnLevel);
-    commands.trigger(Soundtrack::Gameplay);
+    commands.trigger(PlaySoundtrack::Gameplay);
 }
 
 fn exit_playing(mut commands: Commands) {
     // We could use [`StateScoped`] on the sound playing entites instead.
-    commands.trigger(Soundtrack::Disable);
+    commands.trigger(PlaySoundtrack::Disable);
 }
 
 fn return_to_title_screen(mut next_screen: ResMut<NextState<Screen>>) {

--- a/src/screen/playing.rs
+++ b/src/screen/playing.rs
@@ -3,7 +3,9 @@
 use bevy::{input::common_conditions::input_just_pressed, prelude::*};
 
 use super::Screen;
-use crate::game::{audio::soundtrack::PlaySoundtrack, spawn::level::SpawnLevel};
+use crate::game::{
+    assets::SoundtrackKey, audio::soundtrack::PlaySoundtrack, spawn::level::SpawnLevel,
+};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Playing), enter_playing);
@@ -18,7 +20,7 @@ pub(super) fn plugin(app: &mut App) {
 
 fn enter_playing(mut commands: Commands) {
     commands.trigger(SpawnLevel);
-    commands.trigger(PlaySoundtrack::Gameplay);
+    commands.trigger(PlaySoundtrack::Key(SoundtrackKey::Gameplay));
 }
 
 fn exit_playing(mut commands: Commands) {

--- a/src/ui/interaction.rs
+++ b/src/ui/interaction.rs
@@ -1,8 +1,10 @@
 use bevy::prelude::*;
 
+use crate::game::audio::sfx::PlaySfx;
+
 pub(super) fn plugin(app: &mut App) {
     app.register_type::<InteractionPalette>();
-    app.add_systems(Update, apply_interaction_palette);
+    app.add_systems(Update, (apply_interaction_palette, trigger_interaction_sfx));
 }
 
 pub type InteractionQuery<'w, 's, T> =
@@ -27,5 +29,18 @@ fn apply_interaction_palette(
             Interaction::Pressed => palette.pressed,
         }
         .into();
+    }
+}
+
+fn trigger_interaction_sfx(
+    mut interactions: Query<&Interaction, Changed<Interaction>>,
+    mut commands: Commands,
+) {
+    for interaction in &mut interactions {
+        match interaction {
+            Interaction::Hovered => commands.trigger(PlaySfx::ButtonHover),
+            Interaction::Pressed => commands.trigger(PlaySfx::ButtonPress),
+            _ => (),
+        }
     }
 }

--- a/src/ui/interaction.rs
+++ b/src/ui/interaction.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-use crate::game::audio::sfx::PlaySfx;
+use crate::game::{assets::SfxKey, audio::sfx::PlaySfx};
 
 pub(super) fn plugin(app: &mut App) {
     app.register_type::<InteractionPalette>();
@@ -38,8 +38,8 @@ fn trigger_interaction_sfx(
 ) {
     for interaction in &mut interactions {
         match interaction {
-            Interaction::Hovered => commands.trigger(PlaySfx::ButtonHover),
-            Interaction::Pressed => commands.trigger(PlaySfx::ButtonPress),
+            Interaction::Hovered => commands.trigger(PlaySfx::Key(SfxKey::ButtonHover)),
+            Interaction::Pressed => commands.trigger(PlaySfx::Key(SfxKey::ButtonPress)),
             _ => (),
         }
     }


### PR DESCRIPTION
Overview of changes:
- Make some comments a bit more explicit.
- Derive `Copy, Clone` for asset keys.
- Add `sfx::plugin` and `soundtrack::plugin`.
- Rename marker component `SoundtrackMarker` -> `IsSoundtrack`.
- Rename events `Sfx` -> `PlaySfx` and `Soundtrack` -> `PlaySoundtrack`.
- Combine specific-key variants of `PlaySfx` and `PlaySoundtrack`.
- Simplify `play_sfx` and `play_soundtrack` function bodies (this might be controversial).
- Move `game::audio::sfx::button_interaction_sfx` -> `ui::interaction::trigger_interaction_sfx`.