### PR TITLE
Add in prompt for itch-project name.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,11 @@ env:
   # The itch.io page to upload to, in the format: `user-name/project-name`.
   # Comment this out to disable.
   {%- if itch_username != "" %}
+  {%- if itch_project != "" %}
+  ITCH_TARGET: {{itch_username}}/{{itch_project}}
+  {%- else %}
   ITCH_TARGET: {{itch_username}}/{{project-name}}
+  {%- endif %}
   {%- else %}
   # ITCH_TARGET: your-itch-username/{{project-name}}
   {%- endif %}

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -7,4 +7,4 @@ type = "string"
 default = ""
 
 [conditional.'itch_username != ""'.placeholders]
-itch_project = { type = "string", prompt = "Enter the itch.io project name. Leave blank to use the project-name.", default="" }
+itch_project = { type = "string", prompt = "Enter the project name used in the itch.io URL. Leave blank to use this crate's `project-name`.", default = "" }

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -5,3 +5,6 @@ include = ["Cargo.toml", "Cargo.lock", ".github/workflows/*", "*.rs"]
 prompt = "Enter your itch.io username. Leave blank to disable itch.io upload."
 type = "string"
 default = ""
+
+[conditional.'itch_username != ""'.placeholders]
+itch_project = { type = "string", prompt = "Enter the itch.io project name. Leave blank to use the project-name.", default="" }


### PR DESCRIPTION
We now ask for the project name on itch.io if the user provides a username for itch.io. This is optional, and if left-blank we fallback to project-name.

I have to do this weirdly because I can't use template placeholders in `cargo-generate.toml` for defaults, as far as I could tell. We *could* create some hooks, but that is complicated and there are some issues we could run-into so I went this route instead so we wouldn't have to worry as much about it.

To elaborate on the issues with hooks, I'm specifically talking about `init` hooks. `init` *can* have access to `project-name` but it is not guaranteed. So we would have to babysit running order, which can be an issue. Additionally, I'm not completely certain on if they run after the prompt, before the prompt, or during the prompt. In which case we might still run into issues depending on how fast the user moves and all that.

If we run using `pre` hooks, then it runs after the prompt as far as I can tell..which means the default wouldn't be shown to the user anyway, which is the same as the current behavior. The only advantage of `pre` hooks would be that we can eliminate a branch in the release workflow.