### PR TITLE
Fix typos

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -16,7 +16,7 @@ The Bevy Jam working group has agreed on the following guiding design principles
   - Nice IDE support.
   - `cargo-generate` support.
   - Workflows that provide CI and CD with an auto-publish to itch.io.
-  - Builds configured for perfomance by default.
+  - Builds configured for performance by default.
 - Answer questions that will quickly come up when creating an actual game.
   - How do I structure my code?
   - How do I preload assets?

--- a/src/screen/playing.rs
+++ b/src/screen/playing.rs
@@ -24,7 +24,7 @@ fn enter_playing(mut commands: Commands) {
 }
 
 fn exit_playing(mut commands: Commands) {
-    // We could use [`StateScoped`] on the sound playing entites instead.
+    // We could use [`StateScoped`] on the sound playing entities instead.
     commands.trigger(PlaySoundtrack::Disable);
 }
 


### PR DESCRIPTION
I noticed these using the [cSpell VSCode extension](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) while using the template.