### PR TITLE
Use binstall to install wasm-bindgen and wasm-opt

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,7 +122,7 @@ jobs:
       - name: Install and run trunk (Web)
         if: ${{ matrix.platform == 'web' }}
         run: |
-          cargo binstall trunk wasm-bindgen-cli wasm-opt --no-confirm
+          cargo binstall --no-confirm trunk wasm-bindgen-cli wasm-opt
           trunk build --release --dist '${{ env.OUT_DIR }}'
 
       - name: Build binaries (non-Web)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,7 +122,7 @@ jobs:
       - name: Install and run trunk (Web)
         if: ${{ matrix.platform == 'web' }}
         run: |
-          cargo binstall trunk --no-confirm
+          cargo binstall trunk wasm-bindgen-cli wasm-opt --no-confirm
           trunk build --release --dist '${{ env.OUT_DIR }}'
 
       - name: Build binaries (non-Web)


### PR DESCRIPTION
Trunk automatically installs prerequisites, if they're not installed, when calling `trunk build --release`. It looks something like this when it occurs:

![image](https://github.com/user-attachments/assets/b7b9e411-7e3f-4ef1-8cd5-67f6f3bad3a4)

wasm-bindgen installs very quickly, but wasm-opt takes a non-trivial amount of time to install.

It is possible to install these dependencies using `cargo binstall` which can yield time savings.

On my own repository I had a build time of `4m 11s` prior to using `binstall wasm-opt` and a build time of `2m 40s` afterward.
Additionally, I had a build time of `2m 31s` after using `binstall wasm-bindgen-cli`, but I attribute some of this to variance because trunk installing wasm-bindgen only took 5 seconds in the above screenshot.

Nevertheless, it seems worthwhile to install `wasm-opt` via `cargo binstall` and I figured might as well install `wasm-bindgen-cli` as well.

One concern I had is that it's wasm-bindgen*-cli* which seems excessive, but it's what https://github.com/rustwasm/wasm-bindgen suggests... so I went with it.

