### PR TITLE
Add `OnPress` callbacks

### DIFF
--- a/src/screens/credits.rs
+++ b/src/screens/credits.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 use super::Screen;
 use crate::{
     game::{assets::SoundtrackKey, audio::soundtrack::PlaySoundtrack},
-    ui::{prelude::*},
+    ui::prelude::*,
 };
 
 pub(super) fn plugin(app: &mut App) {
@@ -14,7 +14,7 @@ pub(super) fn plugin(app: &mut App) {
 }
 
 fn show_credits_screen(mut commands: Commands) {
-    let on_back = commands.register_one_shot_system(on_back);
+    let enter_title = commands.register_one_shot_system(enter_title);
 
     commands
         .ui_root()
@@ -29,7 +29,7 @@ fn show_credits_screen(mut commands: Commands) {
             children.label("Ducky sprite - CC0 by Caz Creates Games");
             children.label("Music - CC BY 3.0 by Kevin MacLeod");
 
-            children.button("Back").insert(OnPress(on_back));
+            children.button("Back").insert(OnPress(enter_title));
         });
 
     commands.trigger(PlaySoundtrack::Key(SoundtrackKey::Credits));
@@ -39,6 +39,6 @@ fn disable_soundtrack(mut commands: Commands) {
     commands.trigger(PlaySoundtrack::Disable);
 }
 
-fn on_back(mut next_screen: ResMut<NextState<Screen>>) {
+fn enter_title(mut next_screen: ResMut<NextState<Screen>>) {
     next_screen.set(Screen::Title);
 }

--- a/src/screens/credits.rs
+++ b/src/screens/credits.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 use super::Screen;
 use crate::{
     game::{assets::SoundtrackKey, audio::soundtrack::PlaySoundtrack},
-    ui::{interaction::OnPress, prelude::*},
+    ui::{prelude::*},
 };
 
 pub(super) fn plugin(app: &mut App) {

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -3,39 +3,39 @@
 use bevy::prelude::*;
 
 use super::Screen;
-use crate::ui::{prelude::*};
+use crate::ui::prelude::*;
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Title), show_title_screen);
 }
 
 fn show_title_screen(mut commands: Commands) {
-    let on_play = commands.register_one_shot_system(on_play);
-    let on_credits = commands.register_one_shot_system(on_credits);
+    let enter_playing = commands.register_one_shot_system(enter_playing);
+    let enter_credits = commands.register_one_shot_system(enter_credits);
     #[cfg(not(target_family = "wasm"))]
-    let on_exit = commands.register_one_shot_system(on_exit);
+    let exit_app = commands.register_one_shot_system(exit_app);
 
     commands
         .ui_root()
         .insert(StateScoped(Screen::Title))
         .with_children(|children| {
-            children.button("Play").insert(OnPress(on_play));
-            children.button("Credits").insert(OnPress(on_credits));
+            children.button("Play").insert(OnPress(enter_playing));
+            children.button("Credits").insert(OnPress(enter_credits));
 
             #[cfg(not(target_family = "wasm"))]
-            children.button("Exit").insert(OnPress(on_exit));
+            children.button("Exit").insert(OnPress(exit_app));
         });
 }
 
-fn on_play(mut next_screen: ResMut<NextState<Screen>>) {
+fn enter_playing(mut next_screen: ResMut<NextState<Screen>>) {
     next_screen.set(Screen::Playing);
 }
 
-fn on_credits(mut next_screen: ResMut<NextState<Screen>>) {
+fn enter_credits(mut next_screen: ResMut<NextState<Screen>>) {
     next_screen.set(Screen::Credits);
 }
 
 #[cfg(not(target_family = "wasm"))]
-fn on_exit(mut app_exit: EventWriter<AppExit>) {
+fn exit_app(mut app_exit: EventWriter<AppExit>) {
     app_exit.send(AppExit::Success);
 }

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::*;
 
 use super::Screen;
-use crate::ui::prelude::*;
+use crate::ui::{interaction::OnPress, prelude::*};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Title), show_title_screen);
@@ -27,7 +27,11 @@ fn show_title_screen(mut commands: Commands) {
         .ui_root()
         .insert(StateScoped(Screen::Title))
         .with_children(|children| {
-            children.button("Play").insert(TitleAction::Play);
+            children
+                .button("Play")
+                .insert(OnPress(commands.register_one_shot_system(
+                    |mut next_screen: ResMut<NextState<Screen>>| next_screen.set(Screen::Playing),
+                )));
             children.button("Credits").insert(TitleAction::Credits);
 
             #[cfg(not(target_family = "wasm"))]

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -12,6 +12,7 @@ pub(super) fn plugin(app: &mut App) {
 fn show_title_screen(mut commands: Commands) {
     let on_play = commands.register_one_shot_system(on_play);
     let on_credits = commands.register_one_shot_system(on_credits);
+    #[cfg(not(target_family = "wasm"))]
     let on_exit = commands.register_one_shot_system(on_exit);
 
     commands

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::*;
 
 use super::Screen;
-use crate::ui::{interaction::OnPress, prelude::*};
+use crate::ui::{prelude::*};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Title), show_title_screen);

--- a/src/ui/interaction.rs
+++ b/src/ui/interaction.rs
@@ -36,7 +36,7 @@ fn apply_on_press(
     interactions: Query<(&Interaction, &OnPress), Changed<Interaction>>,
     mut commands: Commands,
 ) {
-    for (interaction, OnPress(&system_id)) in &interactions {
+    for (interaction, &OnPress(system_id)) in &interactions {
         if matches!(interaction, Interaction::Pressed) {
             commands.run_system(system_id);
         }

--- a/src/ui/interaction.rs
+++ b/src/ui/interaction.rs
@@ -8,8 +8,8 @@ pub(super) fn plugin(app: &mut App) {
     app.add_systems(
         Update,
         (
+            apply_on_press,
             apply_interaction_palette,
-            apply_interaction_callback,
             trigger_interaction_sfx,
         ),
     );
@@ -31,6 +31,17 @@ pub struct InteractionPalette {
 #[derive(Component, Debug, Reflect, Deref, DerefMut)]
 #[reflect(Component, from_reflect = false)]
 pub struct OnPress(#[reflect(ignore)] pub SystemId);
+
+fn apply_on_press(
+    interactions: Query<(&Interaction, &OnPress), Changed<Interaction>>,
+    mut commands: Commands,
+) {
+    for (interaction, OnPress(system_id)) in &interactions {
+        if matches!(interaction, Interaction::Pressed) {
+            commands.run_system(*system_id);
+        }
+    }
+}
 
 fn apply_interaction_palette(
     mut palette_query: Query<
@@ -57,17 +68,6 @@ fn trigger_interaction_sfx(
             Interaction::Hovered => commands.trigger(PlaySfx::Key(SfxKey::ButtonHover)),
             Interaction::Pressed => commands.trigger(PlaySfx::Key(SfxKey::ButtonPress)),
             _ => (),
-        }
-    }
-}
-
-fn apply_interaction_callback(
-    interactions: Query<(&Interaction, &OnPress), Changed<Interaction>>,
-    mut commands: Commands,
-) {
-    for (interaction, OnPress(system_id)) in &interactions {
-        if matches!(interaction, Interaction::Pressed) {
-            commands.run_system(*system_id);
         }
     }
 }

--- a/src/ui/interaction.rs
+++ b/src/ui/interaction.rs
@@ -25,6 +25,9 @@ pub struct InteractionPalette {
     pub pressed: Color,
 }
 
+/// Component that calls a [one-shot system](https://bevyengine.org/news/bevy-0-12/#one-shot-systems)
+/// when the [`Interaction`] component on the same entity changes to [`Interaction::Pressed`].
+/// Use this in conjuction with [`Commands::register_one_shot_system`] to create a callback for e.g. a button press.
 #[derive(Component, Debug, Reflect, Deref, DerefMut)]
 #[reflect(Component, from_reflect = false)]
 pub struct OnPress(#[reflect(ignore)] pub SystemId);

--- a/src/ui/interaction.rs
+++ b/src/ui/interaction.rs
@@ -36,9 +36,9 @@ fn apply_on_press(
     interactions: Query<(&Interaction, &OnPress), Changed<Interaction>>,
     mut commands: Commands,
 ) {
-    for (interaction, OnPress(system_id)) in &interactions {
+    for (interaction, OnPress(&system_id)) in &interactions {
         if matches!(interaction, Interaction::Pressed) {
-            commands.run_system(*system_id);
+            commands.run_system(system_id);
         }
     }
 }

--- a/src/ui/interaction.rs
+++ b/src/ui/interaction.rs
@@ -1,10 +1,18 @@
-use bevy::prelude::*;
+use bevy::{ecs::system::SystemId, prelude::*};
 
 use crate::game::{assets::SfxKey, audio::sfx::PlaySfx};
 
 pub(super) fn plugin(app: &mut App) {
     app.register_type::<InteractionPalette>();
-    app.add_systems(Update, (apply_interaction_palette, trigger_interaction_sfx));
+    app.register_type::<OnPress>();
+    app.add_systems(
+        Update,
+        (
+            apply_interaction_palette,
+            apply_interaction_callback,
+            trigger_interaction_sfx,
+        ),
+    );
 }
 
 /// Palette for widget interactions. Add this to an entity that supports [`Interaction`]s, such as a button,
@@ -16,6 +24,10 @@ pub struct InteractionPalette {
     pub hovered: Color,
     pub pressed: Color,
 }
+
+#[derive(Component, Debug, Reflect, Deref, DerefMut)]
+#[reflect(Component, from_reflect = false)]
+pub struct OnPress(#[reflect(ignore)] pub SystemId);
 
 fn apply_interaction_palette(
     mut palette_query: Query<
@@ -34,14 +46,25 @@ fn apply_interaction_palette(
 }
 
 fn trigger_interaction_sfx(
-    mut interactions: Query<&Interaction, Changed<Interaction>>,
+    interactions: Query<&Interaction, Changed<Interaction>>,
     mut commands: Commands,
 ) {
-    for interaction in &mut interactions {
+    for interaction in &interactions {
         match interaction {
             Interaction::Hovered => commands.trigger(PlaySfx::Key(SfxKey::ButtonHover)),
             Interaction::Pressed => commands.trigger(PlaySfx::Key(SfxKey::ButtonPress)),
             _ => (),
+        }
+    }
+}
+
+fn apply_interaction_callback(
+    interactions: Query<(&Interaction, &OnPress), Changed<Interaction>>,
+    mut commands: Commands,
+) {
+    for (interaction, OnPress(system_id)) in &interactions {
+        if matches!(interaction, Interaction::Pressed) {
+            commands.run_system(*system_id);
         }
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -9,7 +9,7 @@ mod widgets;
 
 pub mod prelude {
     pub use super::{
-        interaction::InteractionPalette,
+        interaction::{InteractionPalette, OnPress},
         palette as ui_palette,
         widgets::{Containers as _, Widgets as _},
     };


### PR DESCRIPTION
Part of https://github.com/TheBevyFlock/bevy_quickstart/issues/203
Pattern taken from @Freyja-moth. Thanks Freyja!

Alternative to the following:
> `handle_title_action` should be done using observers, rather than a `TitleAction` component

[Relevant discussion](https://discord.com/channels/691052431525675048/1258521739395203174/1270111179494133840).  
The TL;DR is that registering a similar `OnPress<T: Event>(pub T)`, which would be need to trigger observers on presses, would require you to register your `T` in your menu in order to register the actual generic system for your `T`. Which seems like a weird extra abstraction to add and a potential source of errors, same a when a user forgets to do `add_event` for `EventReader`s and `EventWriter`s.
That, or you setup your logic for triggering observers on presses separately for every menu, which seems like a lot of boilerplate for something as trivial as pressing on a button.
Additionally, adding observer structs introduces additional indirection where none is needed.

The ugly reflection stuff is due to https://github.com/bevyengine/bevy/issues/14496.
The need for one-shot systems to be registered at the top of the function will be gone after https://github.com/TheBevyFlock/bevy_quickstart/issues/223