### PR TITLE
Fix memory leak using one-shot systems

### DIFF
--- a/src/screens/credits.rs
+++ b/src/screens/credits.rs
@@ -29,7 +29,7 @@ fn show_credits_screen(mut commands: Commands) {
             children.label("Ducky sprite - CC0 by Caz Creates Games");
             children.label("Music - CC BY 3.0 by Kevin MacLeod");
 
-            children.button("Back").insert(OnPress(enter_title));
+            children.button("Back", enter_title);
         });
 
     commands.trigger(PlaySoundtrack::Key(SoundtrackKey::Credits));

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -19,11 +19,11 @@ fn show_title_screen(mut commands: Commands) {
         .ui_root()
         .insert(StateScoped(Screen::Title))
         .with_children(|children| {
-            children.button("Play").insert(OnPress(enter_playing));
-            children.button("Credits").insert(OnPress(enter_credits));
+            children.button("Play", enter_playing);
+            children.button("Credits", enter_credits);
 
             #[cfg(not(target_family = "wasm"))]
-            children.button("Exit").insert(OnPress(exit_app));
+            children.button("Exit", exit_app);
         });
 }
 

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -1,13 +1,17 @@
 //! Helper traits for creating common widgets.
 
-use bevy::{ecs::system::EntityCommands, prelude::*, ui::Val::*};
+use bevy::{
+    ecs::system::{EntityCommands, SystemId},
+    prelude::*,
+    ui::Val::*,
+};
 
 use super::{interaction::InteractionPalette, palette::*};
 
 /// An extension trait for spawning UI widgets.
 pub trait Widgets {
     /// Spawn a simple button with text.
-    fn button(&mut self, text: impl Into<String>) -> EntityCommands;
+    fn button(&mut self, text: impl Into<String>, on_press: SystemId) -> EntityCommands;
 
     /// Spawn a simple header label. Bigger than [`Widgets::label`].
     fn header(&mut self, text: impl Into<String>) -> EntityCommands;
@@ -17,7 +21,7 @@ pub trait Widgets {
 }
 
 impl<T: Spawn> Widgets for T {
-    fn button(&mut self, text: impl Into<String>) -> EntityCommands {
+    fn button(&mut self, text: impl Into<String>, on_press: SystemId) -> EntityCommands {
         let mut entity = self.spawn((
             Name::new("Button"),
             ButtonBundle {
@@ -50,6 +54,9 @@ impl<T: Spawn> Widgets for T {
                 ),
             ));
         });
+        // Add the one-shot system as a child so that will get cleaned up when the button is destroyed.
+        entity.add_child(on_press.entity());
+
         entity
     }
 

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -54,7 +54,7 @@ impl<T: Spawn> Widgets for T {
                 ),
             ));
         });
-        // Add the one-shot system as a child so that will get cleaned up when the button is destroyed.
+        // Add the one-shot system as a child so that it can be despawned when the button despawns.
         entity.add_child(on_press.entity());
 
         entity


### PR DESCRIPTION
Also implements #234 

Tried adding a closure directly to `fn button`, but that is rather cumbersome, as `ChildBuilder` does not have a `register_one_shot_system` method directly, which means we would have to re-implement it:
```rust
let entity = self.spawn_empty().id();
self.push(RegisterSystem::new(system, entity));
SystemId::from_entity(entity)
```
which is very very *meh*