### PR TITLE
Use observers for callbacks

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -254,6 +254,20 @@ The event `OnPress`, which is [defined in this template](../src/theme/interactio
 is triggered when the button's [`Interaction`](https://docs.rs/bevy/latest/bevy/prelude/enum.Interaction.html)
 component becomes [`Interaction::Pressed`](https://docs.rs/bevy/latest/bevy/prelude/enum.Interaction.html#variant.Pressed).
 
+If your interactions mostly consist of changing the game state, consider using the following helper function:
+
+```rust
+fn spawn_button(mut commands: Commands) {
+    commands.button("Play the game").observe(change_state(Screen::Playing));
+}
+
+fn change_state<S: FreelyMutableState>(
+    new_state: S,
+) -> impl Fn(Trigger<OnPress>, ResMut<NextState<S>>) {
+    move |_trigger, mut next_state| next_state.set(new_state.clone())
+}
+```
+
 ### Reasoning
 
 This pattern is inspired by [bevy_mod_picking](https://github.com/aevyrie/bevy_mod_picking).

--- a/docs/design.md
+++ b/docs/design.md
@@ -270,7 +270,7 @@ fn change_state<S: FreelyMutableState>(
 ### Reasoning
 
 This pattern is inspired by [bevy_mod_picking](https://github.com/aevyrie/bevy_mod_picking).
-By coupling the system handling the interaction to the entity as an observer,
+By pairing the system handling the interaction with the entity as an observer,
 the code running on interactions can be scoped to the exact context of the interaction.
 
 For example, the code for what happens when you press a *specific* button is directly attached to that exact button.

--- a/docs/design.md
+++ b/docs/design.md
@@ -276,8 +276,7 @@ the code running on interactions can be scoped to the exact context of the inter
 For example, the code for what happens when you press a *specific* button is directly attached to that exact button.
 
 This also keeps the interaction logic close to the entity that is interacted with,
-allowing for better code organization. If you want multiple buttons to do the same thing,
-consider triggering a secondary event in their callbacks.
+allowing for better code organization.
 
 ## Dev Tools
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -251,8 +251,7 @@ fn pay_money(_trigger: Trigger<OnPress>, /* Bevy query parameters */) {
 ```
 
 The event `OnPress`, which is [defined in this template](../src/theme/interaction.rs),
-is triggered when the button's [`Interaction`](https://docs.rs/bevy/latest/bevy/prelude/enum.Interaction.html)
-component becomes [`Interaction::Pressed`](https://docs.rs/bevy/latest/bevy/prelude/enum.Interaction.html#variant.Pressed).
+is triggered when the button is [`Interaction::Pressed`](https://docs.rs/bevy/latest/bevy/prelude/enum.Interaction.html#variant.Pressed).
 
 If your interactions mostly consist of changing the game state, consider using the following helper function:
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -245,8 +245,8 @@ fn spawn_button(mut commands: Commands) {
     commands.button("Pay up!").observe(pay_money);
 }
 
-fn pay_money(_trigger: Trigger<OnPress>, /* Bevy query parameters */) {
-    // Handle the interaction
+fn pay_money(_trigger: Trigger<OnPress>, mut money: ResMut<Money>) {
+    money.0 -= 10.0;
 }
 ```
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -257,10 +257,10 @@ If you have many interactions that only change a state, consider using the follo
 
 ```rust
 fn spawn_button(mut commands: Commands) {
-    commands.button("Play the game").observe(change_state(Screen::Playing));
+    commands.button("Play the game").observe(enter_state(Screen::Playing));
 }
 
-fn change_state<S: FreelyMutableState>(
+fn enter_state<S: FreelyMutableState>(
     new_state: S,
 ) -> impl Fn(Trigger<OnPress>, ResMut<NextState<S>>) {
     move |_trigger, mut next_state| next_state.set(new_state.clone())

--- a/docs/design.md
+++ b/docs/design.md
@@ -237,28 +237,34 @@ as custom commands don't return `Entity` or `EntityCommands`. This kind of usage
 ### Pattern
 
 When spawning an entity that can be interacted with, such as a button that can be pressed,
-register a [one-shot system](https://bevyengine.org/news/bevy-0-12/#one-shot-systems) to handle the interaction:
+use an observer to handle the interaction:
 
 ```rust
 fn spawn_button(mut commands: Commands) {
-    let pay_money = commands.register_one_shot_system(pay_money);
-    commands.button("Pay up!", pay_money);
+    // See the Widgets pattern for information on the `button` method
+    commands.button("Pay up!").observe(pay_money);
+}
+
+fn pay_money(_trigger: Trigger<OnPress>, /* Bevy query parameters */) {
+    // Handle the interaction
 }
 ```
 
-The resulting `SystemId` is added as a newtype component on the button entity.
-See the definition of [`OnPress`](../src/theme/interaction.rs) for how this is done.
+The event `OnPress`, which is [defined in this template](../src/theme/interaction.rs),
+is triggered when the button's [`Interaction`](https://docs.rs/bevy/latest/bevy/prelude/enum.Interaction.html)
+component becomes [`Interaction::Pressed`](https://docs.rs/bevy/latest/bevy/prelude/enum.Interaction.html#variant.Pressed).
 
 ### Reasoning
 
 This pattern is inspired by [bevy_mod_picking](https://github.com/aevyrie/bevy_mod_picking).
-By adding the system handling the interaction to the entity as a component,
+By coupling the system handling the interaction to the entity as an observer,
 the code running on interactions can be scoped to the exact context of the interaction.
 
 For example, the code for what happens when you press a *specific* button is directly attached to that exact button.
 
 This also keeps the interaction logic close to the entity that is interacted with,
-allowing for better code organization. If you want multiple buttons to do the same thing, consider triggering an event in their callbacks.
+allowing for better code organization. If you want multiple buttons to do the same thing,
+consider triggering a secondary event in their callbacks.
 
 ## Dev Tools
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -253,7 +253,7 @@ fn pay_money(_trigger: Trigger<OnPress>, mut money: ResMut<Money>) {
 The event `OnPress`, which is [defined in this template](../src/theme/interaction.rs),
 is triggered when the button is [`Interaction::Pressed`](https://docs.rs/bevy/latest/bevy/prelude/enum.Interaction.html#variant.Pressed).
 
-If your interactions mostly consist of changing the game state, consider using the following helper function:
+If you have many interactions that only change a state, consider using the following helper function:
 
 ```rust
 fn spawn_button(mut commands: Commands) {

--- a/src/screens/credits.rs
+++ b/src/screens/credits.rs
@@ -11,8 +11,6 @@ pub(super) fn plugin(app: &mut App) {
 }
 
 fn show_credits_screen(mut commands: Commands) {
-    let enter_title = commands.register_one_shot_system(enter_title);
-
     commands
         .ui_root()
         .insert(StateScoped(Screen::Credits))
@@ -26,7 +24,7 @@ fn show_credits_screen(mut commands: Commands) {
             children.label("Ducky sprite - CC0 by Caz Creates Games");
             children.label("Music - CC BY 3.0 by Kevin MacLeod");
 
-            children.button("Back", enter_title);
+            children.button("Back").observe(enter_title);
         });
 
     commands.play_bgm(BgmHandles::PATH_CREDITS);
@@ -36,6 +34,6 @@ fn stop_bgm(mut commands: Commands) {
     commands.stop_bgm();
 }
 
-fn enter_title(mut next_screen: ResMut<NextState<Screen>>) {
+fn enter_title(_trigger: Trigger<OnPress>, mut next_screen: ResMut<NextState<Screen>>) {
     next_screen.set(Screen::Title);
 }

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -10,32 +10,27 @@ pub(super) fn plugin(app: &mut App) {
 }
 
 fn show_title_screen(mut commands: Commands) {
-    let enter_playing = commands.register_one_shot_system(enter_playing);
-    let enter_credits = commands.register_one_shot_system(enter_credits);
-    #[cfg(not(target_family = "wasm"))]
-    let exit_app = commands.register_one_shot_system(exit_app);
-
     commands
         .ui_root()
         .insert(StateScoped(Screen::Title))
         .with_children(|children| {
-            children.button("Play", enter_playing);
-            children.button("Credits", enter_credits);
+            children.button("Play").observe(enter_playing);
+            children.button("Credits").observe(enter_credits);
 
             #[cfg(not(target_family = "wasm"))]
-            children.button("Exit", exit_app);
+            children.button("Exit").observe(exit_app);
         });
 }
 
-fn enter_playing(mut next_screen: ResMut<NextState<Screen>>) {
+fn enter_playing(_trigger: Trigger<OnPress>, mut next_screen: ResMut<NextState<Screen>>) {
     next_screen.set(Screen::Playing);
 }
 
-fn enter_credits(mut next_screen: ResMut<NextState<Screen>>) {
+fn enter_credits(_trigger: Trigger<OnPress>, mut next_screen: ResMut<NextState<Screen>>) {
     next_screen.set(Screen::Credits);
 }
 
 #[cfg(not(target_family = "wasm"))]
-fn exit_app(mut app_exit: EventWriter<AppExit>) {
+fn exit_app(_trigger: Trigger<OnPress>, mut app_exit: EventWriter<AppExit>) {
     app_exit.send(AppExit::Success);
 }

--- a/src/theme/widgets.rs
+++ b/src/theme/widgets.rs
@@ -14,7 +14,7 @@ use super::{
 /// An extension trait for spawning UI widgets.
 pub trait Widgets {
     /// Spawn a simple button with text.
-    fn button(&mut self, text: impl Into<String>, on_press: SystemId) -> EntityCommands;
+    fn button(&mut self, text: impl Into<String>) -> EntityCommands;
 
     /// Spawn a simple header label. Bigger than [`Widgets::label`].
     fn header(&mut self, text: impl Into<String>) -> EntityCommands;
@@ -24,7 +24,7 @@ pub trait Widgets {
 }
 
 impl<T: Spawn> Widgets for T {
-    fn button(&mut self, text: impl Into<String>, on_press: SystemId) -> EntityCommands {
+    fn button(&mut self, text: impl Into<String>) -> EntityCommands {
         let mut entity = self.spawn((
             Name::new("Button"),
             ButtonBundle {
@@ -43,7 +43,6 @@ impl<T: Spawn> Widgets for T {
                 hovered: BUTTON_HOVERED_BACKGROUND,
                 pressed: BUTTON_PRESSED_BACKGROUND,
             },
-            OnPress(on_press),
         ));
         entity.with_children(|children| {
             children.spawn((


### PR DESCRIPTION
- This variant is probably closer to what will be upstreamed in Bevy, as Alice mentioned wanting to solve this using observers.
- Its implementation is simpler (no need to learn about one-shot systems or `SystemId`, no need to be careful about memory leaks)
- I removed the extra param from `button`. 
  - With the current code, the user does not save on boilerplate when passing the callback to the function. But it incurs a bit of mental indirection that is not present when `observe` is called directly and it requires us to add some ugly generics to the `button` function. I like about the current code that it kinda teaches the user how to apply observers to entities for themselves.
  - Of course, this means a user can forget to handle the `OnPress` event as a consequence.