### PR TITLE
Splash screen allows exiting early (with escape key)

### DIFF
--- a/src/screens/splash.rs
+++ b/src/screens/splash.rs
@@ -40,7 +40,7 @@ pub(super) fn plugin(app: &mut App) {
             .run_if(in_state(Screen::Splash)),
     );
 
-    // exit the splash screen early if the player hits escape
+    // Exit the splash screen early if the player hits escape.
     app.add_systems(
         Update,
         exit_splash_screen
@@ -64,7 +64,7 @@ impl FromWorld for SplashScreenImageList {
     fn from_world(world: &mut World) -> Self {
         let asset_server = world.resource::<AssetServer>();
 
-        // To show your own splash images, replace or add images here
+        // To show your own splash images, replace or add images here.
         Self(VecDeque::from_iter(
             [asset_server.load("images/splash.png")],
         ))
@@ -104,10 +104,10 @@ fn spawn_splash(
     mut next_screen: ResMut<NextState<Screen>>,
 ) {
     if splash_images.0.is_empty() {
-        // if there are no splash images, go directly to the loading screen
+        // If there are no splash images, go directly to the loading screen.
         next_screen.set(Screen::Loading);
     } else {
-        // spawn the UI root but wait for the first timer tick to show an image
+        // Spawn the UI root but wait for the first timer tick to show an image.
         commands.ui_root().insert((
             Name::new("Splash screen container"),
             BackgroundColor(SPLASH_BACKGROUND_COLOR),
@@ -184,9 +184,9 @@ fn check_splash_timer(
         return;
     }
 
-    // try to get the next splash image. If there isn't one, we move on to the next screen
+    // Try to get the next splash image. If there isn't one, we move on to the next screen.
     let Some(next_splash_image) = splash_images.0.pop_front() else {
-        // no more splash screens, exit
+        // There are no more splash screens, exit to the loading screen.
         next_screen.set(Screen::Loading);
         return;
     };
@@ -194,11 +194,10 @@ fn check_splash_timer(
     let container = containers.single();
     commands
         .entity(container)
-        .despawn_descendants() // previous splash images
+        .despawn_descendants()
         .with_children(|parent| {
             parent.spawn(splash_image_bundle(next_splash_image));
         });
 
-    // reset the timer
     timer.0.reset();
 }

--- a/src/screens/splash.rs
+++ b/src/screens/splash.rs
@@ -191,7 +191,10 @@ fn check_splash_timer(
         return;
     };
 
-    let container = containers.single();
+    let Ok(container) = containers.get_single() else {
+        return;
+    };
+
     commands
         .entity(container)
         .despawn_descendants()

--- a/src/screens/splash.rs
+++ b/src/screens/splash.rs
@@ -178,7 +178,7 @@ fn tick_splash_timer(time: Res<Time>, mut timer: ResMut<SplashTimer>) {
 
 fn check_splash_timer(
     mut commands: Commands,
-    mut timer: ResMut<SplashTimer>,
+    timer: Res<SplashTimer>,
     mut next_screen: ResMut<NextState<Screen>>,
     mut splash_images: ResMut<SplashScreenImageList>,
     containers: Query<Entity, With<SplashScreenContainer>>,

--- a/src/screens/splash.rs
+++ b/src/screens/splash.rs
@@ -181,15 +181,15 @@ fn check_splash_timer(
     asset_server: Res<AssetServer>,
     mut timer: ResMut<SplashTimer>,
     mut next_screen: ResMut<NextState<Screen>>,
-    mut splash_screens: ResMut<SplashScreenImageList>,
+    mut splash_images: ResMut<SplashScreenImageList>,
     containers: Query<Entity, With<SplashScreenContainer>>,
 ) {
     if !timer.0.just_finished() {
         return;
     }
 
-    // try to get  the next splash screen. If there isn't one, we move on to the next screen
-    if let Some(next_splash_image) = splash_screens.0.pop_front() {
+    // try to get the next splash image. If there isn't one, we move on to the next screen
+    if let Some(next_splash_image) = splash_images.0.pop_front() {
         // despawn other splash images
         if let Ok(container) = containers.get_single() {
             commands

--- a/src/screens/splash.rs
+++ b/src/screens/splash.rs
@@ -157,7 +157,10 @@ struct SplashTimer(Timer);
 
 impl Default for SplashTimer {
     fn default() -> Self {
-        Self(Timer::from_seconds(SPLASH_DURATION_SECS, TimerMode::Once))
+        Self(Timer::from_seconds(
+            SPLASH_DURATION_SECS,
+            TimerMode::Repeating,
+        ))
     }
 }
 
@@ -201,6 +204,4 @@ fn check_splash_timer(
         .with_children(|parent| {
             parent.spawn(splash_image_bundle(next_splash_image));
         });
-
-    timer.0.reset();
 }

--- a/src/screens/splash.rs
+++ b/src/screens/splash.rs
@@ -63,7 +63,7 @@ impl Default for SplashScreenImageList {
     fn default() -> Self {
         // Use paths here rather than an ImageHandle as the loading screen hasn't
         // run yet. To show your own splash images, replace or add here
-        Self(VecDeque::from_iter(["images/splash.png"].into_iter()))
+        Self(VecDeque::from_iter(["images/splash.png"]))
     }
 }
 
@@ -205,6 +205,5 @@ fn check_splash_timer(
     } else {
         // no more splash screens, exit
         next_screen.set(Screen::Loading);
-        return;
     }
 }


### PR DESCRIPTION
This PR allows the player to exit the splash screen at any time by hitting `KeyCode::escape`.

---

Previously this PR also contained code for displaying multiple splash screens, but after discussion that will be migrated to an example in the bevy repository.