### PR TITLE
Use the new `itch.zone` CDN domain for downloading butler

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -249,7 +249,7 @@ jobs:
 
       - name: Install butler
         run: |
-          curl -L -o butler.zip 'https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default'
+          curl -L -o butler.zip 'https://broth.itch.zone/butler/linux-amd64/LATEST/archive/default'
           unzip butler.zip
           chmod +x butler
           ./butler -V


### PR DESCRIPTION
Itch.io is migrating off the `itch.ovh` CDN domain, to `itch.zone`. They are recommending to use the new domain for downloading butler, see <https://github.com/itchio/butler/issues/257#issuecomment-1832707482>. It's unclear how long `itch.ovh` will remain available.

Fixes #255