### PR TITLE
Fix label alignment

### DIFF
--- a/src/screens/loading.rs
+++ b/src/screens/loading.rs
@@ -22,7 +22,10 @@ fn show_loading_screen(mut commands: Commands) {
         .ui_root()
         .insert(StateScoped(Screen::Loading))
         .with_children(|children| {
-            children.label("Loading...");
+            children.label("Loading...").insert(Style {
+                justify_content: JustifyContent::Center,
+                ..default()
+            });
         });
 }
 

--- a/src/theme/widgets.rs
+++ b/src/theme/widgets.rs
@@ -98,7 +98,7 @@ impl<T: Spawn> Widgets for T {
             NodeBundle {
                 style: Style {
                     width: Px(500.0),
-                    justify_content: JustifyContent::Center,
+                    justify_content: JustifyContent::FlexStart,
                     align_items: AlignItems::Center,
                     ..default()
                 },

--- a/src/theme/widgets.rs
+++ b/src/theme/widgets.rs
@@ -98,7 +98,6 @@ impl<T: Spawn> Widgets for T {
             NodeBundle {
                 style: Style {
                     width: Px(500.0),
-                    justify_content: JustifyContent::FlexStart,
                     align_items: AlignItems::Center,
                     ..default()
                 },


### PR DESCRIPTION
Trivial fix for #220 
We can improve this further in future PRs, but this is at least better for the moment.

<img width="598" alt="image" src="https://github.com/user-attachments/assets/bc3ccd52-9503-42fc-ad8d-80a366239871">
