### PR TITLE
Make YAML indent size 2 in `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[.github/workflows/*.{yaml,yml}]
+indent_size = 2


### PR DESCRIPTION
This makes the indent size for YAML files in `.github/workflows` 2 spaces, as compared to 4. While YAML can technically support any indent size, all of the existing workflows in this repository already use 2 spaces. Furthermore, I had parsing issues in the past using 4 with Github Actions. (I'm unsure if it's a user-error on my part, or some specific of Github Actions.)