### PR TITLE
Remove `web/dist` from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 # Rust builds
 /target
-# Trunk builds
-/web/dist/
-
 # This file contains environment-specific configuration like linker settings
 .cargo/config.toml


### PR DESCRIPTION
We're using `target/` for trunk's build artifacts, so this is no longer needed.