### PR TITLE
Allow running `cargo-generate` workflow on `workflow_dispatch` anywhere

### DIFF
--- a/.github/workflows/cargo-generate.yaml
+++ b/.github/workflows/cargo-generate.yaml
@@ -23,8 +23,8 @@ permissions:
 jobs:
   update:
     runs-on: ubuntu-latest
-    # Only run this job on the source repository, skipping forks.
-    if: ${{ github.repository == 'TheBevyFlock/bevy_quickstart' }}
+    # Only run this job on the source repository, skipping forks, unless it was manually triggered.
+    if: ${{ github.repository == 'TheBevyFlock/bevy_quickstart' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
`cargo-generate.yaml` is an automated Github Action that automatically updates the `cargo-generate` branch from `main`. It's proven to be a bit flaky in the past, so I've found myself testing it on my fork a lot. The issue is that this action is automatically skipped if run on a fork. This is generally good, unless you want to test the workflow specifically and are not an average user.

The amend this, I made the action run if on the source repository OR if it was manually called using `workflow_dispatch`. This way, it won't run when `main` is updated on forks, but still will let developers manually call it if needed.