### PR TITLE
Update `cargo-generate` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install [`cargo-generate`](https://github.com/cargo-generate/cargo-generate) and
 cargo generate TheBevyFlock/bevy_quickstart --branch cargo-generate
 ```
 
-Then in the new generated directory, run the following commands:
+Then navigate to the newly generated directory and run the following commands:
 
 ```sh
 git branch --move main

--- a/README.md
+++ b/README.md
@@ -19,11 +19,18 @@ See our [Design Document](./docs/design.md) for more information on how we struc
 
 ## Create a new game
 
-Install [`cargo-generate`](https://github.com/cargo-generate/cargo-generate) and run the following commands:
+Install [`cargo-generate`](https://github.com/cargo-generate/cargo-generate) and run the following command:
 
 ```sh
 cargo generate TheBevyFlock/bevy_quickstart --branch cargo-generate
+```
+
+Then in the new generated directory, run the following commands:
+
+```sh
 git branch --move main
+cargo update
+git commit -am 'Initial commit'
 ```
 
 Then [create a GitHub repository](https://github.com/new) and push your local repository to it.


### PR DESCRIPTION
Fixes https://github.com/TheBevyFlock/bevy_quickstart/issues/302.

Ideally the template would run `cargo update -p {{package-name}}` for the user in a post-generate script, but it's not clear if there's an easy way to run a CLI command from a Rhai script.